### PR TITLE
Default meta

### DIFF
--- a/HttpTransport_test.go
+++ b/HttpTransport_test.go
@@ -17,7 +17,7 @@ func TestHttpTransportWithFakeServer(t *testing.T) {
 	jsonFormat := NewJSONFormat()
 	ht := NewHttpTransport(testServer.URL, jsonFormat)
 
-	log := New(make(map[string]string))
+	log, _ := New(make(map[string]string))
 	log.AddTransport(ht)
 
 	err := log.Info("SomeEvent", "Message...")
@@ -31,7 +31,7 @@ func TestHttpTransportWithNoServer(t *testing.T) {
 	jsonFormat := NewJSONFormat()
 	ht := NewHttpTransport("http://test-go.travix.com/post", jsonFormat)
 
-	log := New(make(map[string]string))
+	log, _ := New(make(map[string]string))
 	log.AddTransport(ht)
 
 	err := log.Info("SomeEvent", "Message...")

--- a/HttpTransport_test.go
+++ b/HttpTransport_test.go
@@ -17,7 +17,7 @@ func TestHttpTransportWithFakeServer(t *testing.T) {
 	jsonFormat := NewJSONFormat()
 	ht := NewHttpTransport(testServer.URL, jsonFormat)
 
-	log := New()
+	log := New(make(map[string]string))
 	log.AddTransport(ht)
 
 	err := log.Info("SomeEvent", "Message...")
@@ -31,7 +31,7 @@ func TestHttpTransportWithNoServer(t *testing.T) {
 	jsonFormat := NewJSONFormat()
 	ht := NewHttpTransport("http://test-go.travix.com/post", jsonFormat)
 
-	log := New()
+	log := New(make(map[string]string))
 	log.AddTransport(ht)
 
 	err := log.Info("SomeEvent", "Message...")

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import (
 
 func main() {
     defaultMeta := make(map[string]string)
-    myLogger := logger.New(defaultMeta)
+    myLogger, loggerErr := logger.New(defaultMeta)
     myLogger.AddTransport(logger.ConsoleTransport)
 
     // HTTP:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ import (
 )
 
 func main() {
-    myLogger := logger.New()
+    defaultMeta := make(map[string]string)
+    myLogger := logger.New(defaultMeta)
     myLogger.AddTransport(logger.ConsoleTransport)
 
     // HTTP:

--- a/logger.go
+++ b/logger.go
@@ -11,16 +11,23 @@ import (
  * Base struct
  */
 type Logger struct {
-	transports []*Transport
+	transports  []*Transport
+	DefaultMeta map[string]string
 }
 
 /**
- * Transport methods
+ * General methods
  */
 func (l *Logger) AddTransport(t ...*Transport) *Logger {
 	for _, transport := range t {
 		l.transports = append(l.transports, transport)
 	}
+
+	return l
+}
+
+func (l *Logger) SetDefaultMeta(meta map[string]string) *Logger {
+	l.DefaultMeta = meta
 
 	return l
 }
@@ -64,11 +71,19 @@ func (l *Logger) ErrorWithMeta(event string, message string, meta map[string]str
  * Common log method
  */
 func (l *Logger) Log(level string, event string, message string, meta map[string]string) error {
+	combinedMeta := make(map[string]string)
+	for k, v := range l.DefaultMeta {
+		combinedMeta[k] = v
+	}
+	for k, v := range meta {
+		combinedMeta[k] = v
+	}
+
 	entry := NewEntry(
 		level,
 		event,
 		message,
-		meta,
+		combinedMeta,
 	)
 
 	var wg sync.WaitGroup
@@ -128,6 +143,7 @@ out:
 func New() *Logger {
 	l := &Logger{
 		[]*Transport{},
+		make(map[string]string),
 	}
 
 	return l

--- a/logger.go
+++ b/logger.go
@@ -12,7 +12,7 @@ import (
  */
 type Logger struct {
 	transports  []*Transport
-	DefaultMeta map[string]string
+	defaultMeta map[string]string
 }
 
 /**
@@ -22,12 +22,6 @@ func (l *Logger) AddTransport(t ...*Transport) *Logger {
 	for _, transport := range t {
 		l.transports = append(l.transports, transport)
 	}
-
-	return l
-}
-
-func (l *Logger) SetDefaultMeta(meta map[string]string) *Logger {
-	l.DefaultMeta = meta
 
 	return l
 }
@@ -72,7 +66,7 @@ func (l *Logger) ErrorWithMeta(event string, message string, meta map[string]str
  */
 func (l *Logger) Log(level string, event string, message string, meta map[string]string) error {
 	combinedMeta := make(map[string]string)
-	for k, v := range l.DefaultMeta {
+	for k, v := range l.defaultMeta {
 		combinedMeta[k] = v
 	}
 	for k, v := range meta {
@@ -140,10 +134,10 @@ out:
 /**
  * Instantiation
  */
-func New() *Logger {
+func New(meta map[string]string) *Logger {
 	l := &Logger{
 		[]*Transport{},
-		make(map[string]string),
+		meta,
 	}
 
 	return l

--- a/logger.go
+++ b/logger.go
@@ -119,11 +119,15 @@ out:
 	return errs
 }
 
-func New(meta map[string]string) *Logger {
+func New(meta map[string]string) (*Logger, error) {
+	if meta == nil {
+		return nil, errors.New("uninitialized meta provided")
+	}
+
 	l := &Logger{
 		[]*Transport{},
 		meta,
 	}
 
-	return l
+	return l, nil
 }

--- a/logger.go
+++ b/logger.go
@@ -7,17 +7,11 @@ import (
 	"sync"
 )
 
-/**
- * Base struct
- */
 type Logger struct {
 	transports  []*Transport
 	defaultMeta map[string]string
 }
 
-/**
- * General methods
- */
 func (l *Logger) AddTransport(t ...*Transport) *Logger {
 	for _, transport := range t {
 		l.transports = append(l.transports, transport)
@@ -26,9 +20,6 @@ func (l *Logger) AddTransport(t ...*Transport) *Logger {
 	return l
 }
 
-/**
- * Level methods
- */
 func (l *Logger) Debug(event string, message string) error {
 	return l.Log("Debug", event, message, map[string]string{})
 }
@@ -61,9 +52,6 @@ func (l *Logger) ErrorWithMeta(event string, message string, meta map[string]str
 	return l.Log("Error", event, message, meta)
 }
 
-/**
- * Common log method
- */
 func (l *Logger) Log(level string, event string, message string, meta map[string]string) error {
 	combinedMeta := make(map[string]string)
 	for k, v := range l.defaultMeta {
@@ -131,9 +119,6 @@ out:
 	return errs
 }
 
-/**
- * Instantiation
- */
 func New(meta map[string]string) *Logger {
 	l := &Logger{
 		[]*Transport{},

--- a/logger_test.go
+++ b/logger_test.go
@@ -58,7 +58,7 @@ func TestLoggerLog(t *testing.T) {
 		{"Error", "Error", "EventName", "Message..."},
 	}
 
-	log := New(make(map[string]string))
+	log, _ := New(make(map[string]string))
 	log.AddTransport(testTransport)
 
 	for _, item := range tests {
@@ -114,7 +114,7 @@ func TestLoggerLogWithMeta(t *testing.T) {
 		{"Error", "Error", "EventName", "Message...", map[string]string{"key": "value"}},
 	}
 
-	log := New(make(map[string]string))
+	log, _ := New(make(map[string]string))
 	log.AddTransport(testTransport)
 
 	for _, item := range tests {
@@ -161,7 +161,7 @@ func TestLoggerLogWithMeta(t *testing.T) {
 }
 
 func TestLoggerWithDefaultMeta(t *testing.T) {
-	log := New(map[string]string{
+	log, _ := New(map[string]string{
 		"defaultKey": "defaultValue",
 	})
 	log.AddTransport(testTransport)
@@ -189,5 +189,14 @@ func TestLoggerWithDefaultMeta(t *testing.T) {
 
 	if lastLog[3] != "defaultKey=defaultValue" {
 		t.Errorf("expected %s, actual %s", "defaultKey=defaultValue", lastLog[3])
+	}
+}
+
+func TestLoggerWithNilMeta(t *testing.T) {
+	var meta map[string]string
+	_, err := New(meta)
+
+	if err == nil {
+		t.Error("expected error with uninitialized meta")
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -159,3 +159,37 @@ func TestLoggerLogWithMeta(t *testing.T) {
 		})
 	}
 }
+
+func TestLoggerWithDefaultMeta(t *testing.T) {
+	log := New()
+	log.AddTransport(testTransport)
+
+	log.SetDefaultMeta(map[string]string{
+		"defaultKey": "defaultValue",
+	})
+
+	err := log.Info("SomeEvent", "Message")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	lastLog := strings.Split(testWrite.lastLogs[0], " ")
+	testWrite.clearLogs()
+
+	if lastLog[0] != "Info" {
+		t.Errorf("expected %s, actual %s", "Info", lastLog[0])
+	}
+
+	if lastLog[1] != "SomeEvent" {
+		t.Errorf("expected %s, actual %s", "SomeEvent", lastLog[1])
+	}
+
+	if lastLog[2] != "Message" {
+		t.Errorf("expected %s, actual %s", "Message", lastLog[2])
+	}
+
+	if lastLog[3] != "defaultKey=defaultValue" {
+		t.Errorf("expected %s, actual %s", "defaultKey=defaultValue", lastLog[3])
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -58,7 +58,7 @@ func TestLoggerLog(t *testing.T) {
 		{"Error", "Error", "EventName", "Message..."},
 	}
 
-	log := New()
+	log := New(make(map[string]string))
 	log.AddTransport(testTransport)
 
 	for _, item := range tests {
@@ -114,7 +114,7 @@ func TestLoggerLogWithMeta(t *testing.T) {
 		{"Error", "Error", "EventName", "Message...", map[string]string{"key": "value"}},
 	}
 
-	log := New()
+	log := New(make(map[string]string))
 	log.AddTransport(testTransport)
 
 	for _, item := range tests {
@@ -161,12 +161,10 @@ func TestLoggerLogWithMeta(t *testing.T) {
 }
 
 func TestLoggerWithDefaultMeta(t *testing.T) {
-	log := New()
-	log.AddTransport(testTransport)
-
-	log.SetDefaultMeta(map[string]string{
+	log := New(map[string]string{
 		"defaultKey": "defaultValue",
 	})
+	log.AddTransport(testTransport)
 
 	err := log.Info("SomeEvent", "Message")
 


### PR DESCRIPTION
## What's done:

* Logger instances can set their own default meta
* When individual levels are logged, the default meta will get merged to passed meta (if any)

## Why:

It would be useful for our own usage, since our v2 format needs keys like `applicationgroup` and `applicationname` for every log that is being captured.

## Example

```go
log, err := logger.New(map[string]string {
  "key": "value"
})

log.Info("SomeEvent", "message...")

// the log entry would then include key/value pair as meta from default settings
```