### PR TITLE
Added suffix for string format

### DIFF
--- a/StringFormat.go
+++ b/StringFormat.go
@@ -11,9 +11,10 @@ type StringFormat struct {
 	messageFormat     string
 	metaKeyFormat     string
 	metaMessageFormat string
+	lineSuffix        string
 }
 
-func NewStringFormat(levelFormat, eventFormat, messageFormat, metaKeyFormat, metaMessageFormat string) *StringFormat {
+func NewStringFormat(levelFormat, eventFormat, messageFormat, metaKeyFormat, metaMessageFormat, lineSuffix string) *StringFormat {
 	if len(levelFormat) == 0 {
 		return DefaultStringFormat
 	}
@@ -24,6 +25,7 @@ func NewStringFormat(levelFormat, eventFormat, messageFormat, metaKeyFormat, met
 		messageFormat,
 		metaKeyFormat,
 		metaMessageFormat,
+		lineSuffix,
 	}
 }
 
@@ -49,6 +51,8 @@ func (s *StringFormat) Format(e *Entry) (out string, err error) {
 			buf.WriteString(fmt.Sprintf(s.metaMessageFormat, v))
 		}
 	}
+
+	buf.Write([]byte(s.lineSuffix))
 
 	return buf.String(), nil
 }

--- a/StringFormat_test.go
+++ b/StringFormat_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestStringFormat(t *testing.T) {
-	var testStringFormat = NewStringFormat("[%s]", " %s: ", "%s", "\n%s=", "%s")
+	var testStringFormat = NewStringFormat("[%s]", " %s: ", "%s", "\n%s=", "%s", "\nend\n")
 
 	var testMeta = make(map[string]string)
 	testMeta["foo"] = "bar"
@@ -46,12 +46,16 @@ func TestStringFormat(t *testing.T) {
 					t.Errorf("expected to find meta %s, actual %s", m, actual)
 				}
 			}
+
+			if strings.HasSuffix(actual, testStringFormat.lineSuffix) != true {
+				t.Errorf("expected to end with %s, actual %s", testStringFormat.lineSuffix, actual)
+			}
 		})
 	}
 }
 
 func TestStringFormatWithNoEntry(t *testing.T) {
-	var testStringFormat = NewStringFormat("[%s]", " %s: ", "%s", "\n%s=", "%s")
+	var testStringFormat = NewStringFormat("[%s]", " %s: ", "%s", "\n%s=", "%s", "")
 
 	str, err := testStringFormat.Format(nil)
 
@@ -65,7 +69,7 @@ func TestStringFormatWithNoEntry(t *testing.T) {
 }
 
 func TestStringFormatWithNoLevel(t *testing.T) {
-	var testStringFormat = NewStringFormat("", " %s: ", "%s", "%s", "%s")
+	var testStringFormat = NewStringFormat("", " %s: ", "%s", "%s", "%s", "")
 	var testMeta = make(map[string]string)
 	testMeta["key"] = "value"
 


### PR DESCRIPTION
# Description
Expands the string format to have an optional suffix. The default string format remains unchanged.

# Background
When using the console logger in particular, the log messages are printed to the console. Because the format does not include a line break, the messages are all concatenated together, resulting in a completely unreadable format. I don't think this plays well with the log shipping from Kubernetes either.

To mitigate, I've added an optional line suffix. The default format has not changed, so existing applications will not notice this, except for the minor change in method signature if they construct their own custom string formats.