### PR TITLE
This fixes #3 by implementing level filtering per transport.

### DIFF
--- a/LevelFilter.go
+++ b/LevelFilter.go
@@ -1,0 +1,72 @@
+package logger
+
+import "sync"
+import "strings"
+
+// FilterByMinimumLevel only allows messages that are equal to or higher than the specified minimum level
+func FilterByMinimumLevel(levelFilter *LevelFilter) FilterFunc {
+
+	return levelFilter.filter
+}
+
+// LogLevel is a string defining a specific level of log messages
+type LogLevel string
+
+// LevelFilter is used to filter out messages that don't meet the specified minimum level
+//
+// Once the filter is in use somewhere, it is not safe to modify the structure.
+type LevelFilter struct {
+	// Levels is the list of log levels, in increasing order of
+	// severity. Example might be: {"Debug", "Info", "Warning", "Error"}.
+	Levels []LogLevel
+
+	// MinLevel is the minimum level allowed through
+	MinLevel LogLevel
+
+	badLevels map[LogLevel]struct{}
+	once      sync.Once
+}
+
+// NewLevelFilter creates a new filter based on the given minimum level
+//
+// Note that the available levels do not need to be specified, and are set to
+// what this library is capable of.
+func NewLevelFilter(minLevel LogLevel) *LevelFilter {
+	return &LevelFilter{
+		Levels:   []LogLevel{"Debug", "Info", "Warning", "Error"},
+		MinLevel: minLevel,
+	}
+}
+
+// SetMinLevel is used to update the minimum log level
+func (f *LevelFilter) SetMinLevel(min LogLevel) {
+	f.MinLevel = min
+	f.init()
+}
+
+// init calculates the disallowed levels, to prepare for easier filtering
+func (f *LevelFilter) init() {
+	badLevels := make(map[LogLevel]struct{})
+	for _, level := range f.Levels {
+		if strings.EqualFold(string(level), string(f.MinLevel)) {
+			break
+		}
+		badLevels[level] = struct{}{}
+	}
+	f.badLevels = badLevels
+}
+
+func (f *LevelFilter) filter(e *Entry) bool {
+	f.once.Do(f.init)
+
+	// No entry? Then allow.
+	if e == nil {
+		return true
+	}
+
+	// Check if it exists in the list of bad level
+	level := LogLevel(e.Level)
+
+	_, ok := f.badLevels[level]
+	return !ok
+}

--- a/LevelFilter_test.go
+++ b/LevelFilter_test.go
@@ -1,0 +1,78 @@
+package logger
+
+import "testing"
+
+func TestFilterByMinimumLevel(t *testing.T) {
+
+	levelFilter := NewLevelFilter("Debug")
+	filterFunc := FilterByMinimumLevel(levelFilter)
+
+	if filterFunc == nil {
+		t.Error("Nil func constructed, this is not expected")
+	}
+
+	if !filterFunc(&Entry{Level: "Debug"}) {
+		t.Error("Expected that entry at debug level would be allowed, but it isn't")
+	}
+}
+
+func TestNewLevelFilterWithExactExistingLevel(t *testing.T) {
+	minLevel := LogLevel("Info")
+	levelFilter := NewLevelFilter(minLevel)
+	levelFilter.init()
+
+	if levelFilter.MinLevel != "Info" {
+		t.Errorf("Minimum level is not set to %s as expected", minLevel)
+	}
+}
+
+// TestNewLevelFilterWithCasedExistingLevel harnasses against the case where the minimum
+// level is initialized with a different casing.
+func TestNewLevelFilterWithCasedExistingLevel(t *testing.T) {
+	minLevel := LogLevel("INFO")
+	levelFilter := NewLevelFilter(minLevel)
+	levelFilter.init()
+
+	if levelFilter.MinLevel != "INFO" {
+		t.Errorf("Minimum level is not set to %s as expected", minLevel)
+	}
+
+	if levelFilter.filter(&Entry{Level: "Debug"}) {
+		t.Error("Expected that entry at debug level would be disallowed, but it isn't")
+	}
+
+	if !levelFilter.filter(&Entry{Level: "Info"}) {
+		t.Error("Expected that entry at debug level would be allowed, but it isn't")
+	}
+}
+
+func TestFilter(t *testing.T) {
+	minLevel := LogLevel("Info")
+	levelFilter := NewLevelFilter(minLevel)
+
+	if levelFilter.filter(&Entry{Level: "Debug"}) {
+		t.Error("Expected that entry at debug level would be disallowed, but it isn't")
+	}
+
+	if !levelFilter.filter(&Entry{Level: "Info"}) {
+		t.Error("Expected that entry at debug level would be allowed, but it isn't")
+	}
+
+	if !levelFilter.filter(nil) {
+		t.Error("Expected that nil entry would be allowed, but it isn't")
+	}
+}
+
+func TestSetMinLevel(t *testing.T) {
+	minLevel := LogLevel("Info")
+	levelFilter := NewLevelFilter(minLevel)
+
+	if levelFilter.MinLevel != "Info" {
+		t.Errorf("Minimum level is not set to %s as expected", minLevel)
+	}
+
+	levelFilter.SetMinLevel("Warning")
+	if levelFilter.MinLevel != "Warning" {
+		t.Errorf("Minimum level is not set to %s as expected", minLevel)
+	}
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ func main() {
     myLogger.Log("CustomLevelName", "EventName", "message...", map[string]string {
       "key": "value"
     })
+
+    // Level filtering (define per transport!)
+    filteredTransport := logger.NewTransport( ... )
+    filteredTransport.filter = logger.FilterByMinimumLevel(logger.NewLevelFilter("Warning"))
+    myLogger.AddTransport(filteredTransport)
 }
 ```
 

--- a/logger.go
+++ b/logger.go
@@ -80,10 +80,12 @@ func (l *Logger) Log(level string, event string, message string, meta map[string
 		wg.Add(1)
 
 		go func(transport *Transport) {
-			err := transport.log(entry)
+			if transport.filter(entry) {
+				err := transport.log(entry)
 
-			if err != nil {
-				e <- err
+				if err != nil {
+					e <- err
+				}
 			}
 
 			wg.Done()

--- a/logger_test.go
+++ b/logger_test.go
@@ -200,3 +200,33 @@ func TestLoggerWithNilMeta(t *testing.T) {
 		t.Error("expected error with uninitialized meta")
 	}
 }
+
+func TestLoggerWithFilteredTransport(t *testing.T) {
+	log, _ := New(make(map[string]string))
+
+	filteredTestTransport := NewTransport(testWrite, testFormat)
+	filteredTestTransport.filter = FilterByMinimumLevel(NewLevelFilter("Warning"))
+	log.AddTransport(filteredTestTransport)
+
+	testWrite.clearLogs()
+
+	log.Debug("TEST", "Message 1")
+	log.Info("TEST", "Message 2")
+	log.Warn("TEST", "Message 3")
+	log.Error("TEST", "Message 4")
+
+	logs := testWrite.lastLogs
+	expectedLen := 2 // 2 out of 4 messages were allowed
+	if len(logs) != expectedLen {
+		t.Errorf("Found %v entries, expected %v", len(logs), expectedLen)
+	}
+
+	if !strings.Contains(logs[0], "Message 3") {
+		t.Errorf("Message [0] has unpexted value: %s", logs[0])
+	}
+	if !strings.Contains(logs[1], "Message 4") {
+		t.Errorf("Message [1] has unpexted value: %s", logs[1])
+	}
+
+	testWrite.clearLogs()
+}

--- a/transport.go
+++ b/transport.go
@@ -4,9 +4,12 @@ import (
 	"io"
 )
 
+type FilterFunc func(e *Entry) bool
+
 type Transport struct {
 	destination io.Writer
 	formatter   Formatter
+	filter      FilterFunc
 }
 
 type Formatter interface {
@@ -17,6 +20,7 @@ func NewTransport(w io.Writer, f Formatter) *Transport {
 	return &Transport{
 		w,
 		f,
+		FilterAllowAll(),
 	}
 }
 
@@ -30,4 +34,11 @@ func (t *Transport) log(e *Entry) (err error) {
 	_, err = t.destination.Write([]byte(whatToWrite))
 
 	return err
+}
+
+// FilterAllowAll returns a function that will allow any entry, regardless of its contents
+func FilterAllowAll() FilterFunc {
+	return func(e *Entry) bool {
+		return true
+	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -37,3 +37,18 @@ func TestTransportWithFaultyFormat(t *testing.T) {
 		t.Error("expected error from TestFaultyFormat")
 	}
 }
+
+func TestFilterAllowAll(t *testing.T) {
+	filter := FilterAllowAll()
+	if filter == nil {
+		t.Error("Failed ot create filter")
+	}
+
+	if !filter(nil) {
+		t.Error("Expected nil entry to be allowed")
+	}
+
+	if !filter(&Entry{Level: "Debug"}) {
+		t.Error("Expected entry to be allowed")
+	}
+}


### PR DESCRIPTION
# Description
To match existing functionality in pretty much every other log package, messages can now be filtered. The default filter allows every message. The package also includes a filter that filters by a minimum level.

# Details
The implementation is a combination of `github.com/hashicorp/logutils` and https://github.com/Travix-International/travix-logger#console Per transport, you must specify a filter to be used (or it will fall back to the default filter). The implementation of a filter determines whether it can be shared across transports, the built-in filters can be.