### PR TITLE
Fix: filter could not be set due to visibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
 
     // Level filtering (define per transport!)
     filteredTransport := logger.NewTransport( ... )
-    filteredTransport.filter = logger.FilterByMinimumLevel(logger.NewLevelFilter("Warning"))
+    filteredTransport.SetFilter(logger.FilterByMinimumLevel(logger.NewLevelFilter("Warning")))
     myLogger.AddTransport(filteredTransport)
 }
 ```

--- a/transport.go
+++ b/transport.go
@@ -24,6 +24,11 @@ func NewTransport(w io.Writer, f Formatter) *Transport {
 	}
 }
 
+// SetFilter chnages the message filtering to the given filter function.
+func (t *Transport) SetFilter(fn FilterFunc) {
+	t.filter = fn
+}
+
 func (t *Transport) log(e *Entry) (err error) {
 	whatToWrite, err := t.formatter.Format(e)
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -52,3 +52,8 @@ func TestFilterAllowAll(t *testing.T) {
 		t.Error("Expected entry to be allowed")
 	}
 }
+
+func TestSetFilter(t *testing.T) {
+	var testTransport = NewTransport(os.Stdout, DefaultStringFormat)
+	testTransport.SetFilter(FilterByMinimumLevel(NewLevelFilter("Warning")))
+}


### PR DESCRIPTION
# Description
The `filter` of a `Transport` is not exported, thus it cannot be set by consumers. Added an exported function to be able to set/change the filter.

Note: unit tests do not catch these issues because they run from the same package.