### PR TITLE
TR-13144 Escape special characters when marshaling

### DIFF
--- a/JSONFormat.go
+++ b/JSONFormat.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 type jsonEntry struct {
@@ -24,6 +26,10 @@ var (
 	ErrNoMessage = errors.New("No Message!")
 )
 
+func escapeSpecialChars(str string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(strconv.Quote(str), `"`), `"`)
+}
+
 func (j jsonEntry) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 
@@ -39,7 +45,7 @@ func (j jsonEntry) MarshalJSON() ([]byte, error) {
 		return nil, ErrNoMessage
 	}
 
-	_, err := buf.WriteString(fmt.Sprintf("{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\"", j.levelKey, j.Level, j.eventKey, j.Event, j.messageKey, j.Message))
+	_, err := buf.WriteString(fmt.Sprintf("{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\"", j.levelKey, j.Level, j.eventKey, j.Event, j.messageKey, escapeSpecialChars(j.Message)))
 
 	if err != nil {
 		return nil, err
@@ -54,7 +60,7 @@ func (j jsonEntry) MarshalJSON() ([]byte, error) {
 
 		i := len(j.Meta)
 		for k, v := range j.Meta {
-			_, err = buf.WriteString(fmt.Sprintf(" \"%s\":\"%s\"", k, v))
+			_, err = buf.WriteString(fmt.Sprintf(" \"%s\":\"%s\"", k, escapeSpecialChars(v)))
 
 			if err != nil {
 				return nil, err

--- a/JSONFormat_test.go
+++ b/JSONFormat_test.go
@@ -19,6 +19,7 @@ func TestJSONFormat(t *testing.T) {
 		Expected string
 	}{
 		{"Info", "EventName", "Message...", testMeta, `{"level":"Info","event":"EventName","message":"Message...","key":"value"}`},
+		{"Info", "EventName", "a\\U\"", testMeta, `{"level":"Info","event":"EventName","message":"a\\U\"","key":"value"}`}, // Test if special characters are escaped.
 		{"Debug", "EventName", "blah...", testMeta, `{"level":"Debug","event":"EventName","message":"blah...","key":"value"}`},
 		{"Error", "EventName", "blah...", testMeta, `{"level":"Error","event":"EventName","message":"blah...","key":"value"}`},
 	}


### PR DESCRIPTION
Hotfix, I'm not sure this is a complete solution.
Details in the story: https://travix.atlassian.net/browse/TR-13144, and the introduced new unit test case reproduces the problem.

I'm using `strconv.Quote`, which converts a string to an escaped *Go* string literal, so there is no guarantee it conforms to the Json standard, but for the examples I tried, it seems fine.

A long-term solution would be to switch this custom json serialization code to using some library.